### PR TITLE
Add `/sugois` command that exposes sugoi metrics to users

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,12 @@
     "version": "1.0.0",
     "description": "Silly discord bot that reacts to messages with sugoi among other things",
     "main": "index.js",
+    "engines": {
+        "node": ">=20.0.0"
+    },
     "scripts": {
-        "start": "node src/index.js"
+        "start": "node src/index.js",
+        "deploy-commands": "node src/deploy.js"
     },
     "author": "Matthew Galvin",
     "license": "MIT",

--- a/src/client.js
+++ b/src/client.js
@@ -1,0 +1,13 @@
+const { Client, IntentsBitField: { Flags: IntentsFlags } } = require("discord.js");
+
+module.exports = {
+    getClient() {
+        return new Client({
+            intents: [
+                IntentsFlags.Guilds,
+                IntentsFlags.GuildMessages,
+                IntentsFlags.MessageContent,
+            ],
+        });
+    }
+}

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+require("dotenv").config();
+
+const commands = [
+    require("./sugoi").SUGOIS_COMMAND.builder
+];
+
+const client = require("./client").getClient();
+
+
+async function main() {
+    await client.login(process.env.DISCORD_TOKEN);
+
+    const debugGuild = process.env.DEBUG_GUILD;
+
+    let guild;
+    if (!debugGuild) {
+        console.log("Deploying slash commands globally.");
+    } else {
+        guild = await client.guilds.fetch(debugGuild).catch(() => {});
+
+        if (!guild) {
+            console.error("Invalid DEBUG_GUILD. Not deploying any commands.");
+            return;
+        }
+
+        console.log(`Deploying commands to ${guild.name} (${guild.id}).`);
+    }
+
+    // if we're supposed to be deploying to a guild, we only clean up commands in that guild
+    const oldCommands = guild ? await guild.commands.fetch() : await client.application.commands.fetch();
+    console.log(oldCommands.size > 0 ? `Cleaning up ${oldCommands.size} old commands` : "Not cleaning up old commands.");
+
+    // clean up old commands
+    for (const command of oldCommands.values()) {
+        await client.application.commands.delete(command.id).catch(() => {});
+    }
+
+    // deploy new commands
+    for (const command of commands) {
+        console.log(`Deploying ${command.name}.`);
+        await client.application.commands.create(command, debugGuild);
+    }
+}
+
+
+main().then(() => client.destroy());

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,10 @@
 require('dotenv').config();
-const fs = require('fs');
 const {
     EmbedBuilder,
     Colors,
 } = require('discord.js');
+
+const { recordMetrics } = require("./metrics");
 
 const { SUGOIS_COMMAND } = require("./sugoi");
 
@@ -20,61 +21,6 @@ function botLogin() {
         client.on('ready', () => {
             console.log(`Logged in as ${client.user.displayName}`);
         });
-    } catch (error) {
-        console.error(error);
-    }
-}
-
-// Get the metrics object from metrics.json
-function getMetrics() {
-    try {
-        // Check if metrics.json exists
-        if (!fs.existsSync('./metrics.json')) {
-            console.log('metrics.json does not exist. Creating a new file...');
-            // Create a new metrics.json file if it does not exist
-            fs.writeFileSync('./metrics.json', '{}');
-        }
-        // Return the metrics object from metrics.json
-        return JSON.parse(fs.readFileSync('./metrics.json'));
-    } catch (error) {
-        console.error(error);
-    }
-}
-
-// Record user metrics in metrics.json
-async function recordMetrics(message) {
-    try {
-        const metrics = await getMetrics();
-        // Initialize the metrics object if it doesn't exist
-        if (!metrics['times sugoied']) metrics['times sugoied'] = 1;
-        else metrics['times sugoied']++;
-        if (!metrics['users']) metrics['users'] = [];
-        // Add the user to the list of users who have been sugoied
-        if (!metrics['users'].find((user) => user.id === message.author.id))
-            // If the user is not in the list of users who have been sugoied
-            // Add the user to the list of users who have been sugoied
-            // and set the number of times they have been sugoied to 1
-            metrics['users'].push({
-                id: message.author.id,
-                name: message.author.username,
-                sugois: 1,
-            });
-        else {
-            // If the user is in the list of users who have been sugoied
-            // Increment the number of times they have been sugoied
-            const user = metrics['users'].find(
-                (user) => user.id === message.author.id
-            );
-            user.sugois++;
-        }
-        // Write the metrics object to the metrics.json file
-        fs.writeFile(
-            './metrics.json',
-            JSON.stringify(metrics, null, 4),
-            (err) => {
-                if (err) console.error(err);
-            }
-        );
     } catch (error) {
         console.error(error);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -1,21 +1,15 @@
 require('dotenv').config();
 const fs = require('fs');
 const metrics = require('../metrics.json');
-
-// Import the required classes and methods from the discord.js module
 const {
-    Client,
-    IntentsBitField: { Flags: IntentsFlags },
+    EmbedBuilder,
+    Colors,
 } = require('discord.js');
 
+const { SUGOIS_COMMAND } = require("./sugoi");
+
 // Create a new client instance
-const client = new Client({
-    intents: [
-        IntentsFlags.Guilds,
-        IntentsFlags.GuildMessages,
-        IntentsFlags.MessageContent,
-    ],
-});
+const client = require("./client").getClient();
 
 // Regular expression to match the target words
 const SUGOI_REGEX = /sugoi|すごい|unbelievable|🦜|amazing|relink|granblue+/g;
@@ -102,6 +96,28 @@ async function main() {
                 .then(() => {
                     recordMetrics(message);
                 });
+        });
+
+        client.on("interactionCreate", async (interaction) => {
+            try {
+                // for now, just hardcode commands. Probably good enough.
+                if (interaction.commandName == "sugois") {
+                    SUGOIS_COMMAND.handler(interaction);
+                }
+            } catch (error) {
+                console.error(error);
+
+                if (interaction.isRepliable() && !interaction.replied) {
+                    await interaction.reply({
+                        ephemeral: true,
+                        embeds: [
+                            new EmbedBuilder()
+                                .setColor(Colors.Red)
+                                .setDescription("Something went wrong!"),
+                        ],
+                    })
+                }
+            }
         });
     } catch (error) {
         console.error(error);

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+
+// Get the metrics object from metrics.json
+function getMetrics() {
+    try {
+        // Check if metrics.json exists
+        if (!fs.existsSync('./metrics.json')) {
+            console.log('metrics.json does not exist. Creating a new file...');
+            // Create a new metrics.json file if it does not exist
+            fs.writeFileSync('./metrics.json', '{}');
+        }
+        // Return the metrics object from metrics.json
+        return JSON.parse(fs.readFileSync('./metrics.json'));
+    } catch (error) {
+        console.error(error);
+    }
+}
+
+// Record user metrics in metrics.json
+async function recordMetrics(message) {
+    try {
+        const metrics = await getMetrics();
+        // Initialize the metrics object if it doesn't exist
+        if (!metrics['times sugoied']) metrics['times sugoied'] = 1;
+        else metrics['times sugoied']++;
+        if (!metrics['users']) metrics['users'] = [];
+        // Add the user to the list of users who have been sugoied
+        if (!metrics['users'].find((user) => user.id === message.author.id))
+            // If the user is not in the list of users who have been sugoied
+            // Add the user to the list of users who have been sugoied
+            // and set the number of times they have been sugoied to 1
+            metrics['users'].push({
+                id: message.author.id,
+                name: message.author.username,
+                sugois: 1,
+            });
+        else {
+            // If the user is in the list of users who have been sugoied
+            // Increment the number of times they have been sugoied
+            const user = metrics['users'].find(
+                (user) => user.id === message.author.id
+            );
+            user.sugois++;
+        }
+        // Write the metrics object to the metrics.json file
+        fs.writeFile(
+            './metrics.json',
+            JSON.stringify(metrics, null, 4),
+            (err) => {
+                if (err) console.error(err);
+            }
+        );
+    } catch (error) {
+        console.error(error);
+    }
+}
+
+module.exports = { getMetrics, recordMetrics }

--- a/src/sugoi.js
+++ b/src/sugoi.js
@@ -1,7 +1,5 @@
-const fs = require("fs/promises");
 const { ChatInputCommandInteraction, SlashCommandBuilder, EmbedBuilder, Colors } = require("discord.js");
 const { getMetrics } = require("./metrics");
-
 
 module.exports = {
     SUGOIS_COMMAND: {

--- a/src/sugoi.js
+++ b/src/sugoi.js
@@ -1,0 +1,93 @@
+const { join } = require("path");
+const fs = require("fs/promises");
+const { ChatInputCommandInteraction, SlashCommandBuilder, EmbedBuilder, Colors } = require("discord.js");
+
+
+module.exports = {
+    SUGOIS_COMMAND: {
+        builder: new SlashCommandBuilder()
+            .setName("sugois")
+            .setDescription("TODO")
+            .addSubcommand(user => user
+                .setName("user")
+                .setDescription("Get the sugois for a specific user.")
+                .addUserOption(user => user
+                    .setName("user").setDescription("The user to get sugois for. If omitted, gets your own sugois.").setRequired(false)
+                )
+            )
+            .addSubcommand(all => all
+                .setName("all")
+                .setDescription("Get total sugois, including a leaderboard.")
+            ),
+        /**
+         * @param {ChatInputCommandInteraction} interaction
+         */
+        handler: async (interaction) => {
+            if (interaction.commandName != "sugois") throw new Error(`Expected to receive interaction for "sugois", got ${interaction.commandName} (${interaction.commandId})`);
+
+            const subcommand = interaction.options.getSubcommand(true);
+
+            // "require" caches modules, so I'm like, 90% sure we'd be served old metrics after the first time
+            // if we just "require"'d here.
+            const metrics = await fs.readFile(join(__dirname, "..", "metrics.json")).then(JSON.parse);
+
+            if (subcommand == "user") {
+                const user = interaction.options.getUser("user", false) ?? interaction.user;
+
+                const userMetrics = metrics.users.find(({id}) => id == user.id);
+
+                if (!userMetrics) {
+                    await interaction.reply({
+                        embeds: [
+                            new EmbedBuilder()
+                                .setColor(Colors.Red)
+                                .setAuthor({
+                                    name: user.displayName,
+                                    iconURL: user.displayAvatarURL(),
+                                })
+                                .setDescription("This user hasn't sugoied yet!")
+                        ]
+                    });
+                } else {
+                    await interaction.reply({
+                        embeds: [
+                            new EmbedBuilder()
+                                .setColor(Colors.DarkGreen)
+                                .setAuthor({
+                                    name: user.displayName,
+                                    iconURL: user.displayAvatarURL(),
+                                })
+                                .setDescription(
+                                    `Times sugoied: ${userMetrics.sugois}`
+                                ),
+                        ],
+                    });
+                }
+
+            } else if (subcommand == "all") {
+                // sorting can take some time, so we defer our reply
+                await interaction.deferReply();
+
+                const total = metrics["times sugoied"];
+                // this is pretty slow but probably fine for the scale we're working on.
+                // TODO: probably filter by guild members, if command was used in a guild? Alternatively, add additional boolean option
+                const topUsers = metrics.users.toSorted((a, b) => b.sugois - a.sugois).slice(0, 10);
+
+                const embed = new EmbedBuilder()
+                    .setColor(Colors.DarkGreen)
+                    .setTitle("Sugois")
+                    .setDescription(`Total: ${total}`)
+                    .addFields({
+                        name: "Leaderboard",
+                        value: topUsers.map(({id, sugois}, index) => `${index + 1} - <@${id}>: ${sugois}`).join("\n")
+                    });
+
+                await interaction.editReply({
+                    embeds: [embed],
+                });
+            } else {
+                throw new Error(`Unknown subcommand for "sugois": ${subcommand}`);
+            }
+        }
+    }
+}

--- a/src/sugoi.js
+++ b/src/sugoi.js
@@ -1,6 +1,6 @@
-const { join } = require("path");
 const fs = require("fs/promises");
 const { ChatInputCommandInteraction, SlashCommandBuilder, EmbedBuilder, Colors } = require("discord.js");
+const { getMetrics } = require("./metrics");
 
 
 module.exports = {
@@ -27,9 +27,7 @@ module.exports = {
 
             const subcommand = interaction.options.getSubcommand(true);
 
-            // "require" caches modules, so I'm like, 90% sure we'd be served old metrics after the first time
-            // if we just "require"'d here.
-            const metrics = await fs.readFile(join(__dirname, "..", "metrics.json")).then(JSON.parse);
+            const metrics = getMetrics();
 
             if (subcommand == "user") {
                 const user = interaction.options.getUser("user", false) ?? interaction.user;


### PR DESCRIPTION
This PR adds `/sugois user` to to retrieve sugoi metrics for a specific user, and `/sugois all` for a sugoi leaderboard & total count.
It also adds rudimentary slash command handling to the bot and deployment via `npm run deploy-commands` to facilitate this.